### PR TITLE
Log goimport errors

### DIFF
--- a/main.go
+++ b/main.go
@@ -372,5 +372,10 @@ func writeTypes(args *internal.ArgType) error {
 	}
 
 	// process written files with goimports
-	return exec.Command("goimports", params...).Run()
+	output, err := exec.Command("goimports", params...).CombinedOutput()
+	if err != nil {
+		return errors.New(string(output))
+	}
+
+	return nil
 }


### PR DESCRIPTION
Log errors from `goimports`

This change was originally [submitted to xo](https://github.com/xo/xo/pull/183) by @eatonphil but never made it to gendal.

> The original commit was cherry-picked to preserve the authorship, all credits to @eatonphil 