### PR TITLE
Fix outdated import

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -7,7 +7,7 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/knq/dburl"
+	"github.com/xo/dburl"
 
 	"github.com/gedex/inflector"
 	"github.com/knq/snaker"


### PR DESCRIPTION
Currently, running go get fails because [`github.com/knq/dburl`](https://github.com/knq/dburl) moved to [`github.com/xo/dburl`](https://github.com/xo/dburl) (see original PR on xo: xo/xo#161)

```shell script
$ go get -u github.com/turnkey-commerce/gendal
# [truncated]
go: github.com/turnkey-commerce/gendal imports
        github.com/turnkey-commerce/gendal/internal imports
        github.com/knq/dburl: github.com/knq/dburl@v0.0.0-20200124232849-e9ec94f52bc3: parsing go.mod:
        module declares its path as: github.com/xo/dburl
                but was required as: github.com/knq/dburl
```

This PR simply fixes the incorrect import by renaming the dependency to its new name.
