### PR TITLE
Add support for `pgtype`

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,7 @@ options:
   --template-path TEMPLATE-PATH
                          user supplied template path
   --sqlx                 adds foreign key relationship structs and query functions to generated types to use with sqlx library
+  --pg-type PG-TYPE      Use types from the pgtype module. This gives better compatibility for the pgx driver for postgres. [values: <std|pointer|pgtype|pgtype-full>] [default: std]
   --help, -h             display this help and exit
 ```
 
@@ -576,6 +577,29 @@ And when opening a database connection:
 ```go
 db, err := dburl.Open("file:mydatabase.sqlite3?loc=auto")
 ```
+
+### About the `pgx` Driver for Postgres and the `pg-type` Flag
+
+As for the other drivers, `gendal` does not import or use them. However, `pgx`
+is a special case as it will perform better or have more features using the
+types from the `pgtype` module. To use `pgx` to its fullest, the `pg-type`
+argument lets `gendal` know to generate code that uses those types instead of
+the default ones.
+
+The supported modes for the `pg-type` flag are:
+* `std` is the default mode. It will generate code using the types
+from the `sql/database` module.
+* `pgtype-full` will generate code using types from the `pgtype` module
+for every fields and arguments. This mode lets `pgx` use `pgtype` to
+its fullest but the models can look a bit less clean as each field is
+a wrapped type.
+* `pointer` will generate code using the types internal to the
+`pgtype` structures. For nullable fields and arguments, this type will
+be a pointer to that type. If the internal type of the struct cannot be
+used because the struct contains several fields, the equivalent from
+the `std` mode is used instead.
+* `pgtype` is the same as `pointer` except that it will use the `pgtype`
+structures for nullable fields and arguments rather than pointers.
 
 ## About Primary Keys
 For row inserts `gendal` determines whether the primary key is

--- a/gendal.toml
+++ b/gendal.toml
@@ -138,3 +138,8 @@ EscapeColumnNames = false
 # Sqlx adds foreign key relationship structs and query functions to generated types to
 # use with sqlx library
 Sqlx = false
+
+# PgtypeMode changes the types in the generate code to use types from the `pgtype`
+# module rather than the default types from the `sql/database` module.
+# (0 for std, 1 for pgtype-full, 2 for pointer, 3 for pgtype)
+PgtypeMode = 0

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -1,6 +1,9 @@
 package internal
 
-import "database/sql"
+import (
+	"database/sql"
+	"github.com/turnkey-commerce/gendal/loaders/postgrestypes"
+)
 
 // ArgType is the type that specifies the command line arguments.
 type ArgType struct {
@@ -122,6 +125,8 @@ type ArgType struct {
 	// so that users can query foreign key tables using the sqlx library
 	Sqlx bool `arg:"--sqlx,help:adds foreign key relationship structs and query functions to generated types to use with sqlx library"`
 
+	PgtypeMode *postgrestypes.PgtypeMode `arg:"--pg-type,help:Use types from the pgtype module. This gives better compatibility for the pgx driver for postgres. [values: <std|pgtype-full|pointer|pgtype>]"`
+
 	// NameConflictSuffix is the suffix used when a name conflicts with a scoped Go variable.
 	NameConflictSuffix string `arg:"--name-conflict-suffix,-w,help:suffix to append when a name conflicts with a Go variable"`
 
@@ -164,6 +169,7 @@ type ArgType struct {
 // NewDefaultArgs returns the default arguments.
 func NewDefaultArgs() *ArgType {
 	fkMode := FkModeSmart
+	pgtypeMode := postgrestypes.PgtypeModeStd
 
 	return &ArgType{
 		Suffix:              ".xo.go",
@@ -172,6 +178,7 @@ func NewDefaultArgs() *ArgType {
 		ForeignKeyMode:      &fkMode,
 		QueryParamDelimiter: "%%",
 		NameConflictSuffix:  "Val",
+		PgtypeMode:          &pgtypeMode,
 
 		// KnownTypeMap is the collection of known Go types.
 		KnownTypeMap: map[string]bool{

--- a/internal/funcs.go
+++ b/internal/funcs.go
@@ -159,6 +159,7 @@ func (a *ArgType) shortname(typ string, scopeConflicts ...interface{}) string {
 		"regexp":  true,
 		"strings": true,
 		"time":    true,
+		"pgtype":  true,
 	}
 
 	// add scopeConflicts to conflicts

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -71,121 +71,11 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	// extract precision
 	dt, precision, _ = args.ParsePrecision(dt)
 
+	var ok bool
 	var typ string
-	switch dt {
-	case "boolean":
-		nilVal = "false"
-		typ = "bool"
-		if nullable {
-			nilVal = "sql.NullBool{}"
-			typ = "sql.NullBool"
-		}
+	typ, nilVal, ok = postgresNameToGoName(args, dt, nullable, &asSlice)
 
-	case "character", "character varying", "text", "money", "inet":
-		nilVal = `""`
-		typ = "string"
-		if nullable {
-			nilVal = "sql.NullString{}"
-			typ = "sql.NullString"
-		}
-
-	case "smallint":
-		nilVal = "0"
-		typ = "int16"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "integer":
-		nilVal = "0"
-		typ = args.Int32Type
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "bigint":
-		nilVal = "0"
-		typ = "int64"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-
-	case "smallserial":
-		nilVal = "0"
-		typ = "uint16"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "serial":
-		nilVal = "0"
-		typ = args.Uint32Type
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "bigserial":
-		nilVal = "0"
-		typ = "uint64"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-
-	case "real":
-		nilVal = "0.0"
-		typ = "float32"
-		if nullable {
-			nilVal = "sql.NullFloat64{}"
-			typ = "sql.NullFloat64"
-		}
-	case "numeric", "double precision":
-		nilVal = "0.0"
-		typ = "float64"
-		if nullable {
-			nilVal = "sql.NullFloat64{}"
-			typ = "sql.NullFloat64"
-		}
-
-	case "bytea":
-		asSlice = true
-		typ = "byte"
-
-	case "date", "timestamp with time zone", "time with time zone", "time without time zone", "timestamp without time zone":
-		nilVal = "time.Time{}"
-		typ = "time.Time"
-		if nullable {
-			nilVal = "pq.NullTime{}"
-			typ = "pq.NullTime"
-		}
-
-	case "interval":
-		typ = "*time.Duration"
-
-	case `"char"`, "bit":
-		// FIXME: this needs to actually be tested ...
-		// i think this should be 'rune' but I don't think database/sql
-		// supports 'rune' as a type?
-		//
-		// this is mainly here because postgres's pg_catalog.* meta tables have
-		// this as a type.
-		//typ = "rune"
-		nilVal = `uint8(0)`
-		typ = "uint8"
-
-	case `"any"`, "bit varying":
-		asSlice = true
-		typ = "byte"
-
-	case "hstore":
-		typ = "hstore.Hstore"
-
-	case "uuid":
-		nilVal = "uuid.New()"
-		typ = "uuid.UUID"
-
-	default:
+	if !ok {
 		if strings.HasPrefix(dt, args.Schema+".") {
 			// in the same schema, so chop off
 			typ = snaker.SnakeToCamelIdentifier(dt[len(args.Schema)+1:])
@@ -392,4 +282,124 @@ func PgIndexColumns(db models.XODB, schema string, table string, index string) (
 	}
 
 	return ret, nil
+}
+
+func postgresNameToGoName(args *internal.ArgType, dt string, nullable bool, asSlice *bool) (typ string, nilVal string, ok bool) {
+	switch dt {
+	case "boolean":
+		nilVal = "false"
+		typ = "bool"
+		if nullable {
+			nilVal = "sql.NullBool{}"
+			typ = "sql.NullBool"
+		}
+
+	case "character", "character varying", "text", "money", "inet":
+		nilVal = `""`
+		typ = "string"
+		if nullable {
+			nilVal = "sql.NullString{}"
+			typ = "sql.NullString"
+		}
+
+	case "smallint":
+		nilVal = "0"
+		typ = "int16"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "integer":
+		nilVal = "0"
+		typ = args.Int32Type
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "bigint":
+		nilVal = "0"
+		typ = "int64"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "smallserial":
+		nilVal = "0"
+		typ = "uint16"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "serial":
+		nilVal = "0"
+		typ = args.Uint32Type
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "bigserial":
+		nilVal = "0"
+		typ = "uint64"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "real":
+		nilVal = "0.0"
+		typ = "float32"
+		if nullable {
+			nilVal = "sql.NullFloat64{}"
+			typ = "sql.NullFloat64"
+		}
+	case "numeric", "double precision":
+		nilVal = "0.0"
+		typ = "float64"
+		if nullable {
+			nilVal = "sql.NullFloat64{}"
+			typ = "sql.NullFloat64"
+		}
+
+	case "bytea":
+		*asSlice = true
+		typ = "byte"
+
+	case "date", "timestamp with time zone", "time with time zone", "time without time zone", "timestamp without time zone":
+		nilVal = "time.Time{}"
+		typ = "time.Time"
+		if nullable {
+			nilVal = "pq.NullTime{}"
+			typ = "pq.NullTime"
+		}
+
+	case "interval":
+		typ = "*time.Duration"
+
+	case `"char"`, "bit":
+		// FIXME: this needs to actually be tested ...
+		// i think this should be 'rune' but I don't think database/sql
+		// supports 'rune' as a type?
+		//
+		// this is mainly here because postgres's pg_catalog.* meta tables have
+		// this as a type.
+		//typ = "rune"
+		nilVal = `uint8(0)`
+		typ = "uint8"
+
+	case `"any"`, "bit varying":
+		*asSlice = true
+		typ = "byte"
+
+	case "hstore":
+		typ = "hstore.Hstore"
+
+	case "uuid":
+		nilVal = "uuid.New()"
+		typ = "uuid.UUID"
+	default:
+		return "", "", false
+	}
+	return typ, nilVal, true
 }

--- a/loaders/postgres.go
+++ b/loaders/postgres.go
@@ -53,7 +53,6 @@ func PgRelkind(relType internal.RelType) string {
 // definition.
 func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string, string) {
 	precision := 0
-	nilVal := "nil"
 	asSlice := false
 
 	// handle SETOF
@@ -71,9 +70,13 @@ func PgParseType(args *internal.ArgType, dt string, nullable bool) (int, string,
 	// extract precision
 	dt, precision, _ = args.ParsePrecision(dt)
 
-	var ok bool
-	var typ string
-	typ, nilVal, ok = postgresNameToGoName(args, dt, nullable, &asSlice)
+	typ, nilVal, ok := args.PgtypeMode.PostgresNameToPgtypeName(
+		dt,
+		nullable,
+		&asSlice,
+		args.Int32Type,
+		args.Uint32Type,
+	)
 
 	if !ok {
 		if strings.HasPrefix(dt, args.Schema+".") {
@@ -282,124 +285,4 @@ func PgIndexColumns(db models.XODB, schema string, table string, index string) (
 	}
 
 	return ret, nil
-}
-
-func postgresNameToGoName(args *internal.ArgType, dt string, nullable bool, asSlice *bool) (typ string, nilVal string, ok bool) {
-	switch dt {
-	case "boolean":
-		nilVal = "false"
-		typ = "bool"
-		if nullable {
-			nilVal = "sql.NullBool{}"
-			typ = "sql.NullBool"
-		}
-
-	case "character", "character varying", "text", "money", "inet":
-		nilVal = `""`
-		typ = "string"
-		if nullable {
-			nilVal = "sql.NullString{}"
-			typ = "sql.NullString"
-		}
-
-	case "smallint":
-		nilVal = "0"
-		typ = "int16"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "integer":
-		nilVal = "0"
-		typ = args.Int32Type
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-
-	case "bigint":
-		nilVal = "0"
-		typ = "int64"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-
-	case "smallserial":
-		nilVal = "0"
-		typ = "uint16"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "serial":
-		nilVal = "0"
-		typ = args.Uint32Type
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-	case "bigserial":
-		nilVal = "0"
-		typ = "uint64"
-		if nullable {
-			nilVal = "sql.NullInt64{}"
-			typ = "sql.NullInt64"
-		}
-
-	case "real":
-		nilVal = "0.0"
-		typ = "float32"
-		if nullable {
-			nilVal = "sql.NullFloat64{}"
-			typ = "sql.NullFloat64"
-		}
-	case "numeric", "double precision":
-		nilVal = "0.0"
-		typ = "float64"
-		if nullable {
-			nilVal = "sql.NullFloat64{}"
-			typ = "sql.NullFloat64"
-		}
-
-	case "bytea":
-		*asSlice = true
-		typ = "byte"
-
-	case "date", "timestamp with time zone", "time with time zone", "time without time zone", "timestamp without time zone":
-		nilVal = "time.Time{}"
-		typ = "time.Time"
-		if nullable {
-			nilVal = "pq.NullTime{}"
-			typ = "pq.NullTime"
-		}
-
-	case "interval":
-		typ = "*time.Duration"
-
-	case `"char"`, "bit":
-		// FIXME: this needs to actually be tested ...
-		// i think this should be 'rune' but I don't think database/sql
-		// supports 'rune' as a type?
-		//
-		// this is mainly here because postgres's pg_catalog.* meta tables have
-		// this as a type.
-		//typ = "rune"
-		nilVal = `uint8(0)`
-		typ = "uint8"
-
-	case `"any"`, "bit varying":
-		*asSlice = true
-		typ = "byte"
-
-	case "hstore":
-		typ = "hstore.Hstore"
-
-	case "uuid":
-		nilVal = "uuid.New()"
-		typ = "uuid.UUID"
-	default:
-		return "", "", false
-	}
-	return typ, nilVal, true
 }

--- a/loaders/postgrestypes/postgrestypes.go
+++ b/loaders/postgrestypes/postgrestypes.go
@@ -1,0 +1,335 @@
+package postgrestypes
+
+import (
+	"strings"
+	"errors"
+)
+
+// PgtypeMode represents the way types should be generated for postgres.
+type PgtypeMode int
+
+const (
+	// PgtypeModeStd is the default mode. It will generate code using the types
+	// from the `sql/database` module.
+	PgtypeModeStd PgtypeMode = iota
+
+	// PgtypeModeFull will generate code using types from the `pgtype` module
+	// for every fields and arguments. This mode lets `pgx` use `pgtype` to
+	// its fullest but the models can look a bit less clean as each field is
+	// a wrapped type.
+	PgtypeModeFull
+
+	// PgtypeModePointer will generate code using the types intornal to the
+	// `pgtype` structures. For nullable fields and arguments, this type will
+	// be a pointer to that type. If the internal type of the struct cannot be
+	// used because the struct contains several fields, the equivalent from
+	// `PgTypeModeStd` is used instead.
+	PgtypeModePointer
+
+	// Same as `PgtypeModePointer` except that it will use the `pgtype`
+	// structures for nullable fields and arguments.
+	PgtypeModePgtype
+)
+
+// UnmarshalText unmarshals PgtypeMode from text.
+func (p *PgtypeMode) UnmarshalText(text []byte) error {
+	switch strings.ToLower(string(text)) {
+	case "std", "default":
+		*p = PgtypeModeStd
+	case "pgtype-full":
+		*p = PgtypeModeFull
+	case "pointer":
+		*p = PgtypeModePointer
+	case "pgtype":
+		*p = PgtypeModePgtype
+	default:
+		return errors.New("invalid PgtypeMode")
+	}
+
+	return nil
+}
+
+// String satisfies the Stringer interface.
+func (p PgtypeMode) String() string {
+	switch p {
+	case PgtypeModeStd:
+		return "std"
+	case PgtypeModeFull:
+		return "pgtype-full"
+	case PgtypeModePointer:
+		return "pointer"
+	case PgtypeModePgtype:
+		return "pgtype"
+	}
+
+	return "unknown"
+}
+
+func (p PgtypeMode) PostgresNameToPgtypeName(dt string, nullable bool, asSlice *bool, int32Type string, uint32Type string) (typ string, nilVal string, ok bool) {
+	switch p {
+	case PgtypeModeStd:
+		return postgresNameToGoName(dt, nullable, asSlice, int32Type, uint32Type)
+	case PgtypeModeFull:
+		return postgresNameToPgtypeName(dt)
+	case PgtypeModePointer:
+		typ, nilVal, ok = postgresNameToInternalPgtypeName(dt, asSlice, int32Type, uint32Type)
+		if nullable {
+			return "*" + typ, "nil", ok
+		} else {
+			return typ, nilVal, ok
+		}
+	case PgtypeModePgtype:
+		if nullable {
+			return postgresNameToPgtypeName(dt)
+		} else {
+			return postgresNameToInternalPgtypeName(dt, asSlice, int32Type, uint32Type)
+		}
+	default:
+		panic("Unreachable default in PostgresNameToPgtypeName switch.")
+	}
+}
+
+func postgresNameToInternalPgtypeName(dt string, asSlice *bool, int32Type string, uint32Type string) (typ string, nilVal string, ok bool) {
+	switch dt {
+	case "boolean":
+		typ = "bool"
+		nilVal = "false"
+	case "inet":
+		typ = "*net.IPNet"
+		nilVal = "nil"
+	case "character varying":
+		typ = "string"
+		nilVal = `""`
+	case "money", "text", "character":
+		typ = "string"
+		nilVal = `""`
+	case "smallint", "smallserial":
+		typ = "int16"
+		nilVal = "0"
+	case "integer":
+		typ = int32Type
+		nilVal = "0"
+	case "serial":
+		typ = uint32Type
+		nilVal = "0"
+	case "bigint", "bigserial":
+		typ = "int64"
+		nilVal = "0"
+	case "real":
+		typ = "float32"
+		nilVal = "0"
+	case "double precision":
+		typ = "float64"
+		nilVal = "0"
+	case "numeric":
+		typ = "float64"
+		nilVal = "0.0"
+	case "bytea":
+		typ = "[]byte"
+		nilVal = "[]"
+	case "date", "timestamp without time zone", "timestamp with time zone":
+		typ = "time.Time"
+		nilVal = "time.Time{}"
+	case "time with time zone", "time without time zone":
+		// pgtype uses the same type for both types as postgres' type
+		// `time with time zone` does not actually store a time zone.
+		// Source: https://github.com/jackc/pgtype/issues/14#issuecomment-559316485
+		typ = "int64"
+		nilVal = "0"
+	case "interval":
+		typ = "*time.Duration"
+		nilVal = "nil"
+	case `"char"`:
+		typ = "int8"
+		nilVal = "0"
+	case "bit":
+		typ = "uint8"
+		nilVal = `uint8(0)`
+	case "bit varying", `"any"`:
+		typ = "byte"
+		*asSlice = true
+		nilVal = "nil"
+	case "hstore":
+		typ = "hstore.Hstore"
+		nilVal = "nil"
+	case "uuid":
+		typ = "[16]byte"
+		nilVal = "uuid.New()"
+	default:
+		return "", "", false
+	}
+	return typ, nilVal, true
+}
+
+func postgresNameToPgtypeName(dt string) (typ string, nilVal string, ok bool) {
+	switch dt {
+	case "boolean":
+		typ = "pgtype.Bool"
+	case "inet":
+		typ = "pgtype.Inet"
+	case "character varying":
+		typ = "pgtype.Varchar"
+	case "money", "text", "character":
+		typ = "pgtype.Text"
+	case "smallint", "smallserial":
+		typ = "pgtype.Int2"
+	case "integer", "serial":
+		typ = "pgtype.Int4"
+	case "bigint", "bigserial":
+		typ = "pgtype.Int8"
+	case "real":
+		typ = "pgtype.Float4"
+	case "double precision":
+		typ = "pgtype.Float8"
+	case "numeric":
+		typ = "pgtype.Numeric"
+	case "bytea":
+		typ = "pgtype.Bytea"
+	case "date":
+		typ = "pgtype.Date"
+	case "timestamp without time zone":
+		typ = "pgtype.Timestamp"
+	case "timestamp with time zone":
+		typ = "pgtype.Timestamptz"
+	case "time with time zone", "time without time zone":
+		// pgtype uses the same type for both types as postgres' type
+		// `time with time zone` does not actually store a time zone.
+		// Source: https://github.com/jackc/pgtype/issues/14#issuecomment-559316485
+		typ = "pgtype.Time"
+	case "interval":
+		typ = "pgtype.Interval"
+	case `"char"`:
+		typ = "pgtype.QChar"
+	case "bit":
+		typ = "pgtype.Bit"
+	case "bit varying", `"any"`:
+		typ = "pgtype.Varbit"
+	case "hstore":
+		typ = "pgtype.Hstore"
+	case "uuid":
+		typ = "pgtype.UUID"
+	default:
+		return "", "", false
+	}
+	return typ, typ + "{Status: pgtype.Null}", true
+}
+
+func postgresNameToGoName(dt string, nullable bool, asSlice *bool, int32Type string, uint32Type string) (typ string, nilVal string, ok bool) {
+	switch dt {
+	case "boolean":
+		nilVal = "false"
+		typ = "bool"
+		if nullable {
+			nilVal = "sql.NullBool{}"
+			typ = "sql.NullBool"
+		}
+
+	case "character", "character varying", "text", "money", "inet":
+		nilVal = `""`
+		typ = "string"
+		if nullable {
+			nilVal = "sql.NullString{}"
+			typ = "sql.NullString"
+		}
+
+	case "smallint":
+		nilVal = "0"
+		typ = "int16"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "integer":
+		nilVal = "0"
+		typ = int32Type
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "bigint":
+		nilVal = "0"
+		typ = "int64"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "smallserial":
+		nilVal = "0"
+		typ = "uint16"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "serial":
+		nilVal = "0"
+		typ = uint32Type
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+	case "bigserial":
+		nilVal = "0"
+		typ = "uint64"
+		if nullable {
+			nilVal = "sql.NullInt64{}"
+			typ = "sql.NullInt64"
+		}
+
+	case "real":
+		nilVal = "0.0"
+		typ = "float32"
+		if nullable {
+			nilVal = "sql.NullFloat64{}"
+			typ = "sql.NullFloat64"
+		}
+	case "numeric", "double precision":
+		nilVal = "0.0"
+		typ = "float64"
+		if nullable {
+			nilVal = "sql.NullFloat64{}"
+			typ = "sql.NullFloat64"
+		}
+
+	case "bytea":
+		*asSlice = true
+		typ = "byte"
+
+	case "date", "timestamp with time zone", "time with time zone", "time without time zone", "timestamp without time zone":
+		nilVal = "time.Time{}"
+		typ = "time.Time"
+		if nullable {
+			nilVal = "pq.NullTime{}"
+			typ = "pq.NullTime"
+		}
+
+	case "interval":
+		typ = "*time.Duration"
+
+	case `"char"`, "bit":
+		// FIXME: this needs to actually be tested ...
+		// i think this should be 'rune' but I don't think database/sql
+		// supports 'rune' as a type?
+		//
+		// this is mainly here because postgres's pg_catalog.* meta tables have
+		// this as a type.
+		//typ = "rune"
+		nilVal = `uint8(0)`
+		typ = "uint8"
+
+	case `"any"`, "bit varying":
+		*asSlice = true
+		typ = "byte"
+
+	case "hstore":
+		typ = "hstore.Hstore"
+
+	case "uuid":
+		nilVal = "uuid.New()"
+		typ = "uuid.UUID"
+	default:
+		return "", "", false
+	}
+	return typ, nilVal, true
+}

--- a/templates/xo_package.go.tpl
+++ b/templates/xo_package.go.tpl
@@ -12,5 +12,6 @@ import (
 	"regexp"
 	"strings"
 	"time"
+	"github.com/jackc/pgtype"
 )
 


### PR DESCRIPTION
The motivation behind this PR is to add support for [pgx][pgx] and [pgtype][pgtype]. As [gendal does not care SQL drivers][sql-drivers], `gendal` only needs support for `pgtype` to achieve that goal.

This PR adds the flag `--pg-type` to the CLI arguments and to the `gendal.toml` config file. This flag is an enum that can take four values: 
* `std` is the default mode. It will generate code using the types
from the `sql/database` module.
* `pgtype-full` will generate code using types from the `pgtype` module
for every fields and arguments.
* `pointer` will generate code using the types internal to the
`pgtype` structures. For nullable fields and arguments, this type will
be a pointer to that type. If the internal type of the struct cannot be
used because the struct contains several fields, the equivalent from
the `std` mode is used instead.
* `pgtype` is the same as `pointer` except that it will use the `pgtype`
structures for nullable fields and arguments rather than pointers.

This was done to give control to the user over the generated types as some could prefer avoiding the wrapper structures of `pgtype` where possible and others might prefer consistency across the types. This could also influence performance or compatibility with some `pgx` features.

[pgx]: https://github.com/JackC/pgx
[pgtype]: https://github.com/JackC/pgtype
[sql-drivers]: https://github.com/turnkey-commerce/gendal#using-sql-drivers