### PR TITLE
Feat/nullable as proc params

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,7 @@ options:
                          user supplied template path
   --sqlx                 adds foreign key relationship structs and query functions to generated types to use with sqlx library
   --pg-type PG-TYPE      Use types from the pgtype module. This gives better compatibility for the pgx driver for postgres. [values: <std|pointer|pgtype|pgtype-full>] [default: std]
+  --nullable-proc-params Toggles nullable types for stored procedure parameters.
   --help, -h             display this help and exit
 ```
 

--- a/gendal.toml
+++ b/gendal.toml
@@ -143,3 +143,7 @@ Sqlx = false
 # module rather than the default types from the `sql/database` module.
 # (0 for std, 1 for pgtype-full, 2 for pointer, 3 for pgtype)
 PgtypeMode = 0
+
+# NullableProcParams toggle nullable types for stored procedure parameters.
+# (true or false)
+NullableProcParams = false

--- a/internal/argtype.go
+++ b/internal/argtype.go
@@ -164,6 +164,9 @@ type ArgType struct {
 	// ShortNameTypeMap is the collection of Go style short names for types, mainly
 	// used for use with declaring a func receiver on a type.
 	ShortNameTypeMap map[string]string `arg:"-"`
+
+	// NullableProcParams toggle nullable types for stored procedure parameters.
+	NullableProcParams bool `arg:"--nullable-proc-params"`
 }
 
 // NewDefaultArgs returns the default arguments.

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -445,7 +445,7 @@ func (tl TypeLoader) LoadProcParams(args *ArgType, procTpl *Proc) error {
 			Name: fmt.Sprintf("v%d", i),
 		}
 
-		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), true)
+		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), args.NullableProcParams)
 
 		// add to proc params
 		if procTpl.ProcParams != "" {

--- a/internal/loader.go
+++ b/internal/loader.go
@@ -445,8 +445,7 @@ func (tl TypeLoader) LoadProcParams(args *ArgType, procTpl *Proc) error {
 			Name: fmt.Sprintf("v%d", i),
 		}
 
-		// TODO: fix this so that nullable types can be used as parameters
-		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), false)
+		_, _, paramTpl.Type = tl.ParseType(args, strings.TrimSpace(p.ParamType), true)
 
 		// add to proc params
 		if procTpl.ProcParams != "" {


### PR DESCRIPTION
Apparently all of the DBs supported by gendal support nullable parameters, hence using nullable parameters in stored procedures allow for broader effectivness.

I still prefer to make it a user choice and using a cli argument because some user don't want to have nullable variables everywhere, hence `--nullable-proc-params`

Default is `false`, this maintains backward compatibility