### PR TITLE
Fixed type overrides not overriding some types.

### DIFF
--- a/internal/loader.go
+++ b/internal/loader.go
@@ -68,7 +68,7 @@ type TypeLoader struct {
 }
 
 func (tl TypeLoader) ParseType(args *ArgType, dt string, nullable bool) (int, string, string) {
-	if entry, ok := args.internalTypeOverrides[dt]; ok {
+	if entry, ok := args.internalTypeOverrides[strings.ToLower(dt)]; ok {
 		if nullable {
 			return -1, entry.NullableNilValue, entry.NullableType
 		} else {


### PR DESCRIPTION
Due to an oversight with https://github.com/turnkey-commerce/gendal/pull/18, the map used by the type overrides contained
lowered keys but was not checked against lowered values. The confusion
was due to the database engines lowering most values when querying for types.