### PR TITLE
feat: reuse & reference query parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,10 @@ $ go install ./models/
 $ go install ./mssqlmodels/
 ```
 
+> Note: For query generation, the same parameter can be used more than once by
+> referencing it without any type information. For example, the parameter 
+> `%%authorID int%%` can be referenced further in the query with `%%authorID%%`.
+
 ## Command Line Options
 
 Following are `gendal`'s command-line arguments and options. These options can also be set using a [configuration file](#using-a-configuration-file).


### PR DESCRIPTION
Add the ability to reference a query parameter more than once in a query.

The need for this appeared as I was working on some more complex queries and it felt like a useful feature to add.